### PR TITLE
Implementierung von Server Löschung

### DIFF
--- a/src/provisioning/internal/db/db_test.go
+++ b/src/provisioning/internal/db/db_test.go
@@ -62,7 +62,7 @@ func TestServerStore(t *testing.T) {
 		Ip:          "192.168.0.1",
 	}
 
-	iid, err := ipStore.Add(addr)
+	iid, err := ipStore.Add(&addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func TestIpStore(t *testing.T) {
 	db := NewTestConnection()
 	ipStore := NewIPStore(db.Db)
 
-	id, err := ipStore.Add(types.FloatingIP{OpenstackId: "696d03a0-c5c3-4eba-878f-b0aca2d84cd0", Ip: "192.168.0.1"})
+	id, err := ipStore.Add(&types.FloatingIP{OpenstackId: "696d03a0-c5c3-4eba-878f-b0aca2d84cd0", Ip: "192.168.0.1"})
 	if err != nil {
 		t.Fatalf("unable to save ip: %s", err)
 	}
@@ -228,7 +228,7 @@ func TestIpStore(t *testing.T) {
 		t.Fatalf("unable to delete ip: %s", err)
 	}
 
-	ips, err := ipStore.Find(func(i types.FloatingIP) bool { return i.Id == updated.Id })
+	ips, err := ipStore.Find(func(i *types.FloatingIP) bool { return i.Id == updated.Id })
 	if err != nil {
 		t.Fatalf("unable to find ips: %s", err)
 	}

--- a/src/provisioning/internal/db/ip_store.go
+++ b/src/provisioning/internal/db/ip_store.go
@@ -1,0 +1,79 @@
+package db
+
+import (
+	"github.com/Lachstec/mc-hosting/internal/types"
+	"github.com/jmoiron/sqlx"
+)
+
+type IPStore struct {
+	db *sqlx.DB
+}
+
+func NewIPStore(db *sqlx.DB) *IPStore {
+	return &IPStore{db: db}
+}
+
+func (i *IPStore) GetById(id int64) (types.FloatingIP, error) {
+	row := i.db.QueryRowx("SELECT * FROM mch_provisioner.floating_ips WHERE id = $1;", id)
+	var ip types.FloatingIP
+
+	err := row.StructScan(&ip)
+	if err != nil {
+		return types.FloatingIP{}, err
+	}
+	return ip, nil
+}
+
+func (i *IPStore) Find(predicate Predicate[types.FloatingIP]) ([]types.FloatingIP, error) {
+	rows, err := i.db.Queryx("SELECT * FROM mch_provisioner.floating_ips;")
+	if err != nil {
+		return []types.FloatingIP{}, err
+	}
+
+	var ips []types.FloatingIP
+	for rows.Next() {
+		var ip types.FloatingIP
+		err = rows.StructScan(&ip)
+
+		if err != nil {
+			return []types.FloatingIP{}, err
+		}
+
+		if predicate(ip) {
+			ips = append(ips, ip)
+		}
+	}
+
+	return ips, nil
+}
+
+func (i *IPStore) Add(ip types.FloatingIP) (int64, error) {
+	var id int64
+
+	err := i.db.QueryRowx("INSERT INTO mch_provisioner.floating_ips (openstack_id, addr) VALUES ($1, $2) RETURNING id;",
+		ip.OpenstackId, ip.Ip).Scan(&id)
+	if err != nil {
+		return 0, err
+	}
+
+	return id, nil
+}
+
+func (i *IPStore) Update(ip types.FloatingIP) (types.FloatingIP, error) {
+	_, err := i.db.Exec("UPDATE mch_provisioner.floating_ips SET openstack_id = $1, addr = $2 WHERE id = $3;",
+		ip.OpenstackId, ip.Ip, ip.Id)
+
+	if err != nil {
+		return types.FloatingIP{}, err
+	}
+
+	return ip, nil
+}
+
+func (i *IPStore) Delete(ip types.FloatingIP) error {
+	_, err := i.db.Exec("DELETE FROM mch_provisioner.floating_ips WHERE id = $1;", ip.Id)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/provisioning/internal/db/ip_store.go
+++ b/src/provisioning/internal/db/ip_store.go
@@ -9,7 +9,7 @@ type IPStore struct {
 	db *sqlx.DB
 }
 
-func NewIPStore(db *sqlx.DB) *IPStore {
+func NewIPStore(db *sqlx.DB) Store[types.FloatingIP] {
 	return &IPStore{db: db}
 }
 
@@ -21,6 +21,7 @@ func (i *IPStore) GetById(id int64) (types.FloatingIP, error) {
 	if err != nil {
 		return types.FloatingIP{}, err
 	}
+
 	return ip, nil
 }
 

--- a/src/provisioning/internal/db/ip_store.go
+++ b/src/provisioning/internal/db/ip_store.go
@@ -13,42 +13,42 @@ func NewIPStore(db *sqlx.DB) Store[types.FloatingIP] {
 	return &IPStore{db: db}
 }
 
-func (i *IPStore) GetById(id int64) (types.FloatingIP, error) {
+func (i *IPStore) GetById(id int64) (*types.FloatingIP, error) {
 	row := i.db.QueryRowx("SELECT * FROM mch_provisioner.floating_ips WHERE id = $1;", id)
 	var ip types.FloatingIP
 
 	err := row.StructScan(&ip)
 	if err != nil {
-		return types.FloatingIP{}, err
+		return &types.FloatingIP{}, err
 	}
 
-	return ip, nil
+	return &ip, nil
 }
 
-func (i *IPStore) Find(predicate Predicate[types.FloatingIP]) ([]types.FloatingIP, error) {
+func (i *IPStore) Find(predicate Predicate[*types.FloatingIP]) ([]*types.FloatingIP, error) {
 	rows, err := i.db.Queryx("SELECT * FROM mch_provisioner.floating_ips;")
 	if err != nil {
-		return []types.FloatingIP{}, err
+		return []*types.FloatingIP{}, err
 	}
 
-	var ips []types.FloatingIP
+	var ips []*types.FloatingIP
 	for rows.Next() {
 		var ip types.FloatingIP
 		err = rows.StructScan(&ip)
 
 		if err != nil {
-			return []types.FloatingIP{}, err
+			return []*types.FloatingIP{}, err
 		}
 
-		if predicate(ip) {
-			ips = append(ips, ip)
+		if predicate(&ip) {
+			ips = append(ips, &ip)
 		}
 	}
 
 	return ips, nil
 }
 
-func (i *IPStore) Add(ip types.FloatingIP) (int64, error) {
+func (i *IPStore) Add(ip *types.FloatingIP) (int64, error) {
 	var id int64
 
 	err := i.db.QueryRowx("INSERT INTO mch_provisioner.floating_ips (openstack_id, addr) VALUES ($1, $2) RETURNING id;",
@@ -60,18 +60,18 @@ func (i *IPStore) Add(ip types.FloatingIP) (int64, error) {
 	return id, nil
 }
 
-func (i *IPStore) Update(ip types.FloatingIP) (types.FloatingIP, error) {
+func (i *IPStore) Update(ip *types.FloatingIP) (*types.FloatingIP, error) {
 	_, err := i.db.Exec("UPDATE mch_provisioner.floating_ips SET openstack_id = $1, addr = $2 WHERE id = $3;",
 		ip.OpenstackId, ip.Ip, ip.Id)
 
 	if err != nil {
-		return types.FloatingIP{}, err
+		return &types.FloatingIP{}, err
 	}
 
 	return ip, nil
 }
 
-func (i *IPStore) Delete(ip types.FloatingIP) error {
+func (i *IPStore) Delete(ip *types.FloatingIP) error {
 	_, err := i.db.Exec("DELETE FROM mch_provisioner.floating_ips WHERE id = $1;", ip.Id)
 	if err != nil {
 		return err

--- a/src/provisioning/internal/db/key_store.go
+++ b/src/provisioning/internal/db/key_store.go
@@ -1,0 +1,79 @@
+package db
+
+import (
+	"github.com/Lachstec/mc-hosting/internal/types"
+	"github.com/jmoiron/sqlx"
+)
+
+type KeyStore struct {
+	db *sqlx.DB
+}
+
+func NewKeyStore(db *sqlx.DB) Store[types.Key] {
+	return &KeyStore{db: db}
+}
+
+func (k *KeyStore) GetById(id int64) (types.Key, error) {
+	row := k.db.QueryRowx("SELECT * FROM mch_provisioner.keypairs WHERE id=$1;", id)
+	var key types.Key
+	err := row.StructScan(&key)
+
+	if err != nil {
+		return types.Key{}, err
+	}
+	return key, nil
+}
+
+func (k *KeyStore) Find(predicate Predicate[types.Key]) ([]types.Key, error) {
+	rows, err := k.db.Queryx("SELECT * FROM mch_provisioner.keypairs;")
+	if err != nil {
+		return []types.Key{}, err
+	}
+
+	var keys []types.Key
+	for rows.Next() {
+		var key types.Key
+		err = rows.StructScan(&key)
+
+		if err != nil {
+			return []types.Key{}, err
+		}
+
+		if predicate(key) {
+			keys = append(keys, key)
+		}
+	}
+
+	return keys, nil
+}
+
+func (k *KeyStore) Add(key types.Key) (int64, error) {
+	var id int64
+
+	err := k.db.QueryRowx("INSERT INTO mch_provisioner.keypairs (name, public_key, private_key) VALUES ($1, $2, $3) RETURNING id;",
+		key.Name, key.PublicKey, key.PrivateKey).Scan(&id)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return id, nil
+}
+
+func (k *KeyStore) Update(key types.Key) (types.Key, error) {
+	_, err := k.db.Exec("UPDATE mch_provisioner.keypairs SET name = $1, public_key = $2, private_key = $3 WHERE id = $4;",
+		key.Name, key.PublicKey, key.PrivateKey, key.Id)
+	if err != nil {
+		return types.Key{}, err
+	}
+
+	return key, nil
+}
+
+func (k *KeyStore) Delete(key types.Key) error {
+	_, err := k.db.Exec("DELETE FROM mch_provisioner.keypairs WHERE id=$1;", key.Id)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/provisioning/internal/db/key_store.go
+++ b/src/provisioning/internal/db/key_store.go
@@ -13,41 +13,41 @@ func NewKeyStore(db *sqlx.DB) Store[types.Key] {
 	return &KeyStore{db: db}
 }
 
-func (k *KeyStore) GetById(id int64) (types.Key, error) {
+func (k *KeyStore) GetById(id int64) (*types.Key, error) {
 	row := k.db.QueryRowx("SELECT * FROM mch_provisioner.keypairs WHERE id=$1;", id)
 	var key types.Key
 	err := row.StructScan(&key)
 
 	if err != nil {
-		return types.Key{}, err
+		return &types.Key{}, err
 	}
-	return key, nil
+	return &key, nil
 }
 
-func (k *KeyStore) Find(predicate Predicate[types.Key]) ([]types.Key, error) {
+func (k *KeyStore) Find(predicate Predicate[*types.Key]) ([]*types.Key, error) {
 	rows, err := k.db.Queryx("SELECT * FROM mch_provisioner.keypairs;")
 	if err != nil {
-		return []types.Key{}, err
+		return []*types.Key{}, err
 	}
 
-	var keys []types.Key
+	var keys []*types.Key
 	for rows.Next() {
 		var key types.Key
 		err = rows.StructScan(&key)
 
 		if err != nil {
-			return []types.Key{}, err
+			return []*types.Key{}, err
 		}
 
-		if predicate(key) {
-			keys = append(keys, key)
+		if predicate(&key) {
+			keys = append(keys, &key)
 		}
 	}
 
 	return keys, nil
 }
 
-func (k *KeyStore) Add(key types.Key) (int64, error) {
+func (k *KeyStore) Add(key *types.Key) (int64, error) {
 	var id int64
 
 	err := k.db.QueryRowx("INSERT INTO mch_provisioner.keypairs (name, public_key, private_key) VALUES ($1, $2, $3) RETURNING id;",
@@ -60,17 +60,17 @@ func (k *KeyStore) Add(key types.Key) (int64, error) {
 	return id, nil
 }
 
-func (k *KeyStore) Update(key types.Key) (types.Key, error) {
+func (k *KeyStore) Update(key *types.Key) (*types.Key, error) {
 	_, err := k.db.Exec("UPDATE mch_provisioner.keypairs SET name = $1, public_key = $2, private_key = $3 WHERE id = $4;",
 		key.Name, key.PublicKey, key.PrivateKey, key.Id)
 	if err != nil {
-		return types.Key{}, err
+		return &types.Key{}, err
 	}
 
 	return key, nil
 }
 
-func (k *KeyStore) Delete(key types.Key) error {
+func (k *KeyStore) Delete(key *types.Key) error {
 	_, err := k.db.Exec("DELETE FROM mch_provisioner.keypairs WHERE id=$1;", key.Id)
 	if err != nil {
 		return err

--- a/src/provisioning/internal/db/server_store.go
+++ b/src/provisioning/internal/db/server_store.go
@@ -53,7 +53,7 @@ func (s *ServerStore) Add(server *types.Server) (int64, error) {
 		server.UserID,
 		server.OpenstackID,
 		server.Name,
-		server.Address.String(),
+		server.Address,
 		server.Status,
 		server.Port,
 		server.Flavour,

--- a/src/provisioning/internal/db/server_store.go
+++ b/src/provisioning/internal/db/server_store.go
@@ -51,7 +51,7 @@ func (s *ServerStore) Add(server *types.Server) (int64, error) {
 	err := s.db.QueryRowx(
 		"INSERT INTO mch_provisioner.servers(userid, openstack_id, name, addr, status, port, flavour, image, game, game_version, game_mode, difficulty, whitelist_enabled, pvp_enabled, players_max, ssh_key) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) RETURNING id;",
 		server.UserID,
-		server.OpenstackID,
+		server.OpenstackId,
 		server.Name,
 		server.Address,
 		server.Status,
@@ -77,7 +77,7 @@ func (s *ServerStore) Update(server *types.Server) (*types.Server, error) {
 	var updated types.Server
 	err := s.db.QueryRowx(
 		"UPDATE mch_provisioner.servers SET openstack_id = $1, name = $2, addr = $3, status = $4, port = $5, flavour = $6, image = $7, game = $8, game_version = $9, game_mode = $10, difficulty = $11, whitelist_enabled = $12, pvp_enabled = $13, players_max = $14 WHERE id = $15 RETURNING *;",
-		server.OpenstackID,
+		server.OpenstackId,
 		server.Name,
 		server.Address,
 		server.Status,

--- a/src/provisioning/internal/services/minecraft_provisioner_services.go
+++ b/src/provisioning/internal/services/minecraft_provisioner_services.go
@@ -345,6 +345,10 @@ func (m *MinecraftProvisioner) NewGameServer(ctx context.Context, server *types.
 	return server, nil
 }
 
+// DeleteGameServer completely de-provisions the given server. It does this by
+// first deleting the compute instance, then the keypair associated with it. After that,
+// the attached volume with game data gets deleted and as a last thing, the floating
+// ip that was used to make it accessible gets released.
 func (m *MinecraftProvisioner) DeleteGameServer(ctx context.Context, server types.Server) error {
 	backups, err := m.backupstore.Find(func(b *types.Backup) bool { return b.ServerID == server.ID })
 	if err != nil {

--- a/src/provisioning/internal/services/minecraft_provisioner_services.go
+++ b/src/provisioning/internal/services/minecraft_provisioner_services.go
@@ -392,6 +392,9 @@ func (m *MinecraftProvisioner) DeleteGameServer(ctx context.Context, server type
 	for _, backup := range backups {
 		log.Println("Deleting backup: ", backup.OpenstackID)
 		err = volumes.Delete(ctx, storageClient, backup.OpenstackID, nil).ExtractErr()
+		if err != nil {
+			log.Println("Error deleting volume: ", err)
+		}
 		log.Println("Deleting backup: ", backup.OpenstackID)
 		err = m.WaitForVolumeReady(ctx, backup.OpenstackID, time.Minute*2)
 		if err != nil {

--- a/src/provisioning/internal/services/minecraft_provisioner_services.go
+++ b/src/provisioning/internal/services/minecraft_provisioner_services.go
@@ -127,7 +127,7 @@ func (m *MinecraftProvisioner) newKeyPair(ctx context.Context, name string, publ
 	key := types.Key{
 		Name:       keys.Name,
 		PublicKey:  []byte(keys.PublicKey),
-		PrivateKey: []byte(keys.PrivateKey),
+		PrivateKey: []byte(privateKey),
 	}
 
 	id, err := m.keystore.Add(&key)

--- a/src/provisioning/internal/types/floating_ip.go
+++ b/src/provisioning/internal/types/floating_ip.go
@@ -5,5 +5,9 @@ import "net"
 type FloatingIP struct {
 	Id          int64
 	OpenstackId string `db:"openstack_id"`
-	Ip          net.IP `db:"addr"`
+	Ip          string `db:"addr"`
+}
+
+func (f *FloatingIP) GetIP() net.IP {
+	return net.ParseIP(f.Ip)
 }

--- a/src/provisioning/internal/types/floating_ip.go
+++ b/src/provisioning/internal/types/floating_ip.go
@@ -2,12 +2,17 @@ package types
 
 import "net"
 
+// FloatingIP represents a Floating IP that can be associated to a types.Server.
 type FloatingIP struct {
-	Id          int64
+	// Id is the unique identifier for the FloatingIP in the database.
+	Id int64
+	// OpenstackId is the ID of the FloatingIP in Open Stack
 	OpenstackId string `db:"openstack_id"`
-	Ip          string `db:"addr"`
+	// Ip contains the actual outside-facing IP Address
+	Ip string `db:"addr"`
 }
 
+// GetIP returns a net.IP containing the stored IP Address.
 func (f *FloatingIP) GetIP() net.IP {
 	return net.ParseIP(f.Ip)
 }

--- a/src/provisioning/internal/types/floating_ip.go
+++ b/src/provisioning/internal/types/floating_ip.go
@@ -1,0 +1,9 @@
+package types
+
+import "net"
+
+type FloatingIP struct {
+	Id          int64
+	OpenstackId string `db:"openstack_id"`
+	Ip          net.IP `db:"addr"`
+}

--- a/src/provisioning/internal/types/key.go
+++ b/src/provisioning/internal/types/key.go
@@ -6,7 +6,7 @@ type Key struct {
 	// Name of the Keypair in OpenStack
 	Name string
 	// PublicKey part of the Keypair.
-	PublicKey []byte
+	PublicKey []byte `db:"public_key"`
 	// PrivateKey part of the Keypair.
-	PrivateKey []byte
+	PrivateKey []byte `db:"private_key"`
 }

--- a/src/provisioning/internal/types/key.go
+++ b/src/provisioning/internal/types/key.go
@@ -1,0 +1,11 @@
+package types
+
+// Key represents a SSH Keypair for use with OpenStack.
+type Key struct {
+	// Name of the Keypair in OpenStack
+	Name string
+	// PublicKey part of the Keypair.
+	PublicKey []byte
+	// PrivateKey part of the Keypair.
+	PrivateKey []byte
+}

--- a/src/provisioning/internal/types/key.go
+++ b/src/provisioning/internal/types/key.go
@@ -1,7 +1,8 @@
 package types
 
-// Key represents a SSH Keypair for use with OpenStack.
+// Key represents an SSH Keypair for use with OpenStack.
 type Key struct {
+	Id int64
 	// Name of the Keypair in OpenStack
 	Name string
 	// PublicKey part of the Keypair.

--- a/src/provisioning/internal/types/server.go
+++ b/src/provisioning/internal/types/server.go
@@ -1,7 +1,5 @@
 package types
 
-import "net"
-
 type ServerStatus string
 
 const (
@@ -47,7 +45,7 @@ type Server struct {
 	UserID           int64        `db:"userid"`
 	OpenstackId      string       `db:"openstack_id"`
 	Name             string       `db:"name" json:"name"`
-	Address          net.IP       `db:"addr"`
+	Address          int64        `db:"addr"`
 	Status           ServerStatus `db:"status"`
 	Port             int          `db:"port"`
 	Flavour          int64        `db:"flavour"`

--- a/src/provisioning/internal/types/server.go
+++ b/src/provisioning/internal/types/server.go
@@ -45,7 +45,7 @@ const (
 type Server struct {
 	ID               int64
 	UserID           int64        `db:"userid"`
-	OpenstackID      string       `db:"openstack_id"`
+	OpenstackId      string       `db:"openstack_id"`
 	Name             string       `db:"name" json:"name"`
 	Address          net.IP       `db:"addr"`
 	Status           ServerStatus `db:"status"`
@@ -59,5 +59,5 @@ type Server struct {
 	WhitelistEnabled bool         `db:"whitelist_enabled" json:"whitelist_enabled"`
 	PvPEnabled       bool         `db:"pvp_enabled" json:"pvp_enabled"`
 	PlayersMax       int          `db:"players_max" json:"players_max"`
-	SSHKey           []byte       `db:"ssh_key"`
+	SSHKey           int64        `db:"ssh_key"`
 }

--- a/src/provisioning/migrations/2_keypairs.down.sql
+++ b/src/provisioning/migrations/2_keypairs.down.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+ALTER TABLE mch_provisioner.servers
+DROP CONSTRAINT fk_ssh_key;
+
+ALTER TABLE mch_provisioner.servers
+DROP COLUMN ssh_key;
+
+ALTER TABLE mch_provisioner.servers
+    ADD COLUMN ssh_key BYTEA;
+
+DROP TABLE mch_provisioner.keypairs;
+
+COMMIT;

--- a/src/provisioning/migrations/2_keypairs.up.sql
+++ b/src/provisioning/migrations/2_keypairs.up.sql
@@ -1,7 +1,8 @@
 BEGIN;
 
 CREATE TABLE mch_provisioner.keypairs(
-    name VARCHAR PRIMARY KEY,
+    id SERIAL PRIMARY KEY,
+    name VARCHAR,
     public_key BYTEA,
     private_key BYTEA
 );
@@ -10,11 +11,11 @@ ALTER TABLE mch_provisioner.servers
 DROP COLUMN ssh_key;
 
 ALTER TABLE mch_provisioner.servers
-ADD COLUMN ssh_key VARCHAR;
+ADD COLUMN ssh_key INT;
 
 ALTER TABLE mch_provisioner.servers
 ADD CONSTRAINT fk_ssh_key
 FOREIGN KEY (ssh_key)
-REFERENCES mch_provisioner.keypairs(name);
+REFERENCES mch_provisioner.keypairs(id);
 
 COMMIT;

--- a/src/provisioning/migrations/2_keypairs.up.sql
+++ b/src/provisioning/migrations/2_keypairs.up.sql
@@ -1,0 +1,20 @@
+BEGIN;
+
+CREATE TABLE mch_provisioner.keypairs(
+    name VARCHAR PRIMARY KEY,
+    public_key BYTEA,
+    private_key BYTEA
+);
+
+ALTER TABLE mch_provisioner.servers
+DROP COLUMN ssh_key;
+
+ALTER TABLE mch_provisioner.servers
+ADD COLUMN ssh_key VARCHAR;
+
+ALTER TABLE mch_provisioner.servers
+ADD CONSTRAINT fk_ssh_key
+FOREIGN KEY (ssh_key)
+REFERENCES mch_provisioner.keypairs(name);
+
+COMMIT;

--- a/src/provisioning/migrations/3_floating_ips.down.sql
+++ b/src/provisioning/migrations/3_floating_ips.down.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+ALTER TABLE mch_provisioner.servers
+DROP CONSTRAINT fk_floating_ip;
+
+ALTER TABLE mch_provisioner.servers
+DROP COLUMN addr;
+
+ALTER TABLE mch_provisioner.servers
+ADD COLUMN addr INET;
+
+DROP TABLE mch_provisioner.floating_ips;
+
+COMMIT;

--- a/src/provisioning/migrations/3_floating_ips.up.sql
+++ b/src/provisioning/migrations/3_floating_ips.up.sql
@@ -1,0 +1,20 @@
+BEGIN;
+
+CREATE TABLE mch_provisioner.floating_ips(
+    id SERIAL PRIMARY KEY,
+    openstack_id UUID NOT NULL,
+    addr INET NOT NULL
+);
+
+ALTER TABLE mch_provisioner.servers
+DROP COLUMN addr;
+
+ALTER TABLE mch_provisioner.servers
+ADD COLUMN addr INT;
+
+ALTER TABLE mch_provisioner.servers
+ADD CONSTRAINT fk_floating_ip
+FOREIGN KEY (addr)
+REFERENCES mch_provisioner.floating_ips(id);
+
+COMMIT;


### PR DESCRIPTION
Die PR implementiert das Löschen von Servern. Dazu müssen zuerst weitere Informationen in der Datenbank abgelegt werden, insbesondere die UUIDs von den Resourcen in OpenStack. Dann wird über Gophercloud alles gelöscht, was mit dem Server zusammenhängt.

- Neue Tables `mch_provisioner.floating_ips` und `mch_provisioner.keypairs` im Schema
- Neue Funktion `DeleteGameServer` zum Löschen eines erstellten Gameservers
- Anpassung der alten Types ans neue Schema

Mögliche Verbesserung wäre noch, dass die Errors von den Funktionen repräsentieren, was schief gegangen ist, damit dass dann in den Responses von der API wiedergegeben werden kann. Closes #48 